### PR TITLE
Consolidate configuration into main.yaml

### DIFF
--- a/config.py
+++ b/config.py
@@ -881,7 +881,7 @@ def test():
     
 if __name__ == "__main__":
     #test()
-    cfg = Config.load_singleton('test.yaml')
+    cfg = Config.load_singleton('main.yaml')
     exported = cfg.export("json")
     print("## EXPORT(JSON, redacted)")
     print(json.dumps(json.loads(exported), ensure_ascii=False, indent=2))

--- a/main.yaml
+++ b/main.yaml
@@ -51,3 +51,23 @@ logger:
       - key
       - credential
       - pwd
+task_system:
+  pool:
+    default_ttl: 120.0
+    backend:
+      type: memory
+  executor:
+    max_concurrency: 4
+    lease_batch_size: 10
+    lease_ttl: 30.0
+    prefetch: 20
+    idle_sleep: 0.5
+    max_retries: 2
+    backoff_base: 0.5
+    backoff_jitter: 0.3
+    task_timeout: null
+    rate_limit_per_sec: null
+    rate_limit_burst: null
+    failure_delay: null
+    filters: {}
+    requeue_on_failure: true

--- a/parallel_executor.py
+++ b/parallel_executor.py
@@ -1,0 +1,325 @@
+"""Parallel executor coordinating work from TaskPool."""
+from __future__ import annotations
+
+import concurrent.futures
+import queue
+import random
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Mapping, Optional
+
+from logger import StructuredLogger
+
+from task_pool import LeasedTask, TaskPool
+from task_system_config import get_executor_value
+
+
+logger = StructuredLogger.get_logger("cad.parallel_executor")
+
+
+def _policy_value(key: str, typ: type, *, default: Optional[object] = None, required: bool = False):
+    if not required and default is None:
+        raw = get_executor_value(key, Any, default=None)
+        if raw is None:
+            return None
+        if isinstance(raw, typ):
+            return raw
+        if typ in (int, float, bool):
+            return typ(raw)
+        if typ is dict and isinstance(raw, Mapping):
+            return raw
+        raise TypeError(f"Configuration key task_system.executor.{key} has incompatible type: {type(raw)!r}")
+    return get_executor_value(key, typ, default, required=required)
+
+
+@dataclass
+class ExecutorPolicy:
+    max_concurrency: int = field(default_factory=lambda: _policy_value("max_concurrency", int, required=True))
+    lease_batch_size: int = field(default_factory=lambda: _policy_value("lease_batch_size", int, required=True))
+    lease_ttl: float = field(default_factory=lambda: _policy_value("lease_ttl", float, required=True))
+    prefetch: int = field(default_factory=lambda: _policy_value("prefetch", int, required=True))
+    idle_sleep: float = field(default_factory=lambda: _policy_value("idle_sleep", float, required=True))
+    max_retries: int = field(default_factory=lambda: _policy_value("max_retries", int, required=True))
+    backoff_base: float = field(default_factory=lambda: _policy_value("backoff_base", float, required=True))
+    backoff_jitter: float = field(default_factory=lambda: _policy_value("backoff_jitter", float, required=True))
+    task_timeout: Optional[float] = field(default_factory=lambda: _policy_value("task_timeout", float, default=None))
+    rate_limit_per_sec: Optional[float] = field(default_factory=lambda: _policy_value("rate_limit_per_sec", float, default=None))
+    rate_limit_burst: Optional[int] = field(default_factory=lambda: _policy_value("rate_limit_burst", int, default=None))
+    failure_delay: Optional[float] = field(default_factory=lambda: _policy_value("failure_delay", float, default=None))
+    filters: Optional[Mapping[str, object]] = field(default_factory=lambda: _policy_value("filters", dict, default=None))
+    requeue_on_failure: bool = field(default_factory=lambda: _policy_value("requeue_on_failure", bool, required=True))
+
+
+@dataclass
+class ExecutorEvents:
+    on_start: Callable[["ParallelExecutor"], None] = lambda executor: None
+    on_lease: Callable[["ParallelExecutor", LeasedTask], None] = lambda executor, leased: None
+    on_success: Callable[["ParallelExecutor", LeasedTask, float], None] = lambda executor, leased, latency: None
+    on_retry: Callable[["ParallelExecutor", LeasedTask, int, Exception], None] = lambda executor, leased, attempt, exc: None
+    on_dead: Callable[["ParallelExecutor", LeasedTask, Exception], None] = lambda executor, leased, exc: None
+    on_stop: Callable[["ParallelExecutor"], None] = lambda executor: None
+
+
+class TokenBucket:
+    def __init__(self, rate: float, burst: Optional[int]) -> None:
+        self._rate = rate
+        self._capacity = float(burst if burst is not None else max(1.0, rate))
+        self._tokens = self._capacity
+        self._updated = time.time()
+        self._lock = threading.Lock()
+
+    def acquire(self, amount: float = 1.0) -> None:
+        while True:
+            with self._lock:
+                now = time.time()
+                elapsed = now - self._updated
+                self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+                self._updated = now
+                if self._tokens >= amount:
+                    self._tokens -= amount
+                    return
+                deficit = (amount - self._tokens) / self._rate
+            if deficit > 0:
+                time.sleep(deficit)
+
+
+class ParallelExecutor:
+    def __init__(
+        self,
+        policy: ExecutorPolicy,
+        events: Optional[ExecutorEvents] = None,
+    ) -> None:
+        if policy.max_concurrency <= 0:
+            raise ValueError("max_concurrency must be positive")
+        if policy.lease_batch_size <= 0:
+            raise ValueError("lease_batch_size must be positive")
+        if policy.rate_limit_per_sec is not None and policy.rate_limit_per_sec <= 0:
+            raise ValueError("rate_limit_per_sec must be positive when provided")
+        self._policy = policy
+        self._events = events or ExecutorEvents()
+        self._stop_event = threading.Event()
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=policy.max_concurrency)
+        self._inflight: List[concurrent.futures.Future] = []
+        self._inflight_lock = threading.Lock()
+        self._prefetch_queue: "queue.Queue[LeasedTask]" = queue.Queue(maxsize=policy.prefetch)
+        self._rate_limiter = (
+            TokenBucket(policy.rate_limit_per_sec, policy.rate_limit_burst)
+            if policy.rate_limit_per_sec
+            else None
+        )
+
+    @classmethod
+    def run(
+        cls,
+        handler: Callable[[LeasedTask], None],
+        pool: TaskPool,
+        policy: ExecutorPolicy,
+        events: Optional[ExecutorEvents] = None,
+    ) -> "ParallelExecutor":
+        executor = cls(policy, events)
+        executor.start()
+        try:
+            executor._loop(handler, pool)
+        finally:
+            executor.graceful_shutdown()
+        return executor
+
+    def start(self) -> None:
+        logger.info("executor.start", concurrency=self._policy.max_concurrency)
+        self._events.on_start(self)
+
+    def stop(self) -> None:
+        logger.info("executor.stop_requested")
+        self._stop_event.set()
+
+    def graceful_shutdown(self, timeout: Optional[float] = None) -> None:
+        logger.info("executor.graceful_shutdown.begin")
+        self._stop_event.set()
+        with self._inflight_lock:
+            futures = list(self._inflight)
+        for idx, future in enumerate(futures):
+            if idx in (0, len(futures) // 2, len(futures) - 1):
+                state = "done" if future.done() else "running" if future.running() else "pending"
+                logger.debug("executor.wait_future", future_state=state)
+            if timeout is not None:
+                future.result(timeout=timeout)
+            else:
+                future.result()
+        self._executor.shutdown(wait=True)
+        self._events.on_stop(self)
+        logger.info("executor.graceful_shutdown.end")
+
+    def submit(self, leased: LeasedTask, handler: Callable[[LeasedTask], None], pool: TaskPool) -> None:
+        if self._rate_limiter is not None:
+            self._rate_limiter.acquire(1.0)
+        future = self._executor.submit(self._execute_task, leased, handler, pool)
+        with self._inflight_lock:
+            self._inflight.append(future)
+        future.add_done_callback(self._on_future_done)
+
+    def _on_future_done(self, future: concurrent.futures.Future) -> None:
+        with self._inflight_lock:
+            if future in self._inflight:
+                self._inflight.remove(future)
+
+    def _loop(self, handler: Callable[[LeasedTask], None], pool: TaskPool) -> None:
+        while not self._stop_event.is_set():
+            self._fill_prefetch(pool)
+            dispatched = 0
+            while not self._prefetch_queue.empty():
+                try:
+                    leased = self._prefetch_queue.get_nowait()
+                except queue.Empty:  # pragma: no cover - defensive
+                    break
+                self.submit(leased, handler, pool)
+                dispatched += 1
+            if dispatched:
+                logger.debug("executor.dispatched", count=dispatched)
+            with self._inflight_lock:
+                active = len(self._inflight)
+            if self._prefetch_queue.empty() and active == 0:
+                idle_stats = pool.stats()
+                if idle_stats.get("visible", 0) == 0:
+                    logger.info("executor.idle_exit")
+                    break
+            time.sleep(self._policy.idle_sleep)
+
+    def _fill_prefetch(self, pool: TaskPool) -> None:
+        if self._prefetch_queue.full():
+            return
+        request = min(
+            self._policy.lease_batch_size,
+            self._policy.prefetch - self._prefetch_queue.qsize(),
+        )
+        if request <= 0:
+            return
+        leased = pool.lease(request, self._policy.lease_ttl, filters=self._policy.filters)
+        for idx, item in enumerate(leased):
+            if idx in (0, len(leased) // 2, len(leased) - 1):
+                logger.debug(
+                    "executor.leased",
+                    task_id=item.task.task_id,
+                    deadline=item.lease_deadline,
+                    attempt=item.attempt,
+                )
+            self._events.on_lease(self, item)
+            try:
+                self._prefetch_queue.put_nowait(item)
+            except queue.Full:  # pragma: no cover - defensive
+                pool.nack(item.task.task_id, requeue=True, delay=self._policy.failure_delay)
+                break
+        if not leased:
+            logger.debug("executor.no_lease")
+
+    def _execute_task(self, leased: LeasedTask, handler: Callable[[LeasedTask], None], pool: TaskPool) -> None:
+        attempt = 0
+        while attempt <= self._policy.max_retries:
+            start = time.time()
+            try:
+                result = self._invoke_with_timeout(handler, leased)
+                latency = time.time() - start
+                pool.ack(leased.task.task_id)
+                logger.info(
+                    "executor.task_success",
+                    task_id=leased.task.task_id,
+                    attempt=attempt,
+                    latency=latency,
+                )
+                self._events.on_success(self, leased, latency)
+                return result
+            except Exception as exc:  # pragma: no cover - high level catch
+                latency = time.time() - start
+                attempt += 1
+                if attempt <= self._policy.max_retries:
+                    backoff = self._policy.backoff_base * (2 ** (attempt - 1))
+                    jitter = random.uniform(0, self._policy.backoff_jitter)
+                    delay = backoff + jitter
+                    logger.warning(
+                        "executor.task_retry",
+                        task_id=leased.task.task_id,
+                        attempt=attempt,
+                        delay=delay,
+                        error=str(exc),
+                    )
+                    pool.heartbeat(leased.task.task_id)
+                    self._events.on_retry(self, leased, attempt, exc)
+                    time.sleep(delay)
+                    continue
+                logger.error(
+                    "executor.task_failed",
+                    task_id=leased.task.task_id,
+                    error=str(exc),
+                    latency=latency,
+                )
+                self._events.on_dead(self, leased, exc)
+                pool.nack(
+                    leased.task.task_id,
+                    requeue=self._policy.requeue_on_failure,
+                    delay=self._policy.failure_delay,
+                )
+                return
+
+    def _invoke_with_timeout(self, handler: Callable[[LeasedTask], None], leased: LeasedTask):
+        if self._policy.task_timeout is None:
+            return handler(leased)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as tmp:
+            future = tmp.submit(handler, leased)
+            return future.result(timeout=self._policy.task_timeout)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import unittest
+
+    from task_partitioner import TaskPartitioner
+
+    class ParallelExecutorTests(unittest.TestCase):
+        def setUp(self) -> None:
+            plan = TaskPartitioner.plan(
+                {"job_id": "job-ex"},
+                [
+                    {"payload_ref": "item-1", "weight": 1.0, "group_key": "A"},
+                    {"payload_ref": "item-2", "weight": 1.0, "group_key": "A"},
+                    {"payload_ref": "item-3", "weight": 1.0, "group_key": "B"},
+                ],
+                "fixed",
+                {"max_items_per_task": 2},
+            )
+            self.pool = TaskPool()
+            self.pool.put(plan.tasks)
+            self.handled: List[str] = []
+            self.expected_tasks = len(plan.tasks)
+
+        def handler(self, leased: LeasedTask) -> None:
+            time.sleep(0.05)
+            self.handled.append(leased.task.task_id)
+
+        def test_executor_processes_all_tasks(self) -> None:
+            policy = ExecutorPolicy(max_concurrency=2, lease_batch_size=2, lease_ttl=5.0, prefetch=4)
+            ParallelExecutor.run(self.handler, self.pool, policy)
+            self.assertGreaterEqual(len(self.handled), self.expected_tasks)
+
+        def test_retry_flow(self) -> None:
+            self.pool.put(TaskPartitioner.plan(
+                {"job_id": "job-retry"},
+                [{"payload_ref": "item-4", "weight": 1.0, "group_key": "B"}],
+                "fixed",
+                {"max_items_per_task": 1},
+            ).tasks)
+
+            calls: List[int] = []
+
+            def flaky(task: LeasedTask) -> None:
+                calls.append(1)
+                if len(calls) < 2:
+                    raise RuntimeError("boom")
+
+            policy = ExecutorPolicy(max_concurrency=1, lease_batch_size=1, lease_ttl=5.0, prefetch=1, max_retries=1)
+            ParallelExecutor.run(flaky, self.pool, policy)
+            self.assertGreaterEqual(len(calls), 2)
+
+    unittest.main()

--- a/task_pool.py
+++ b/task_pool.py
@@ -1,0 +1,616 @@
+"""Task pool implementations.
+
+Provides TaskPool with configurable backends and concurrency safety.
+"""
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+from logger import StructuredLogger
+from task_partitioner import TaskRecord
+from task_system_config import get_pool_value
+
+
+logger = StructuredLogger.get_logger("cad.task_pool")
+
+
+@dataclass
+class LeasedTask:
+    task: TaskRecord
+    lease_id: str
+    lease_deadline: float
+    attempt: int
+    metadata: Mapping[str, Union[str, int, float, None]] = field(default_factory=dict)
+
+
+@dataclass
+class _TaskEntry:
+    task: TaskRecord
+    priority: int
+    visible_at: float
+    expires_at: Optional[float]
+    lease_deadline: Optional[float]
+    lease_id: Optional[str]
+    attempt: int
+    idempotency_key: Optional[str]
+    metadata: Dict[str, Union[str, int, float, None]]
+    last_exception: Optional[str] = None
+    last_reason: Optional[str] = None
+    retry_count: int = 0
+
+    def is_visible(self, now: float) -> bool:
+        if self.expires_at is not None and now >= self.expires_at:
+            return False
+        return self.visible_at <= now and self.lease_deadline is None
+
+    def lease_expired(self, now: float) -> bool:
+        return self.lease_deadline is not None and now >= self.lease_deadline
+
+
+class TaskPoolBackend:
+    def put(self, entries: Sequence[_TaskEntry]) -> None:
+        raise NotImplementedError
+
+    def lease(self, max_n: int, lease_ttl: float, filters: Optional[Mapping[str, Union[str, int, float]]] = None) -> List[_TaskEntry]:
+        raise NotImplementedError
+
+    def ack(self, task_id: str) -> bool:
+        raise NotImplementedError
+
+    def nack(self, task_id: str, *, requeue: bool, delay: Optional[float]) -> bool:
+        raise NotImplementedError
+
+    def heartbeat(self, task_id: str) -> bool:
+        raise NotImplementedError
+
+    def mark_dead(self, task_id: str, reason: str) -> bool:
+        raise NotImplementedError
+
+    def stats(self) -> Mapping[str, Union[int, float]]:
+        raise NotImplementedError
+
+    def drain(self, predicate: Callable[[TaskRecord], bool]) -> List[TaskRecord]:
+        raise NotImplementedError
+
+
+class InMemoryBackend(TaskPoolBackend):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._ready: List[Tuple[int, int, _TaskEntry]] = []
+        self._delayed: List[Tuple[float, int, _TaskEntry]] = []
+        self._leased: Dict[str, _TaskEntry] = {}
+        self._dead: Dict[str, _TaskEntry] = {}
+        self._sequence = 0
+
+    def _log_queue_state(self, event: str) -> None:
+        logger.debug(
+            event,
+            ready=len(self._ready),
+            delayed=len(self._delayed),
+            leased=len(self._leased),
+            dead=len(self._dead),
+        )
+
+    def _match_filters(self, entry: _TaskEntry, filters: Optional[Mapping[str, Union[str, int, float]]]) -> bool:
+        if not filters:
+            return True
+        for key, expected in filters.items():
+            actual = entry.metadata.get(key) or entry.task.extras.get(key)
+            if actual != expected:
+                return False
+        return True
+
+    def _requeue_expired_locked(self, now: float) -> None:
+        expired = [task_id for task_id, entry in self._leased.items() if entry.lease_expired(now)]
+        if expired:
+            for idx, task_id in enumerate(expired):
+                entry = self._leased.pop(task_id)
+                entry.lease_deadline = None
+                entry.lease_id = None
+                entry.retry_count += 1
+                entry.visible_at = now
+                self._push_ready(entry)
+                if idx in (0, len(expired) // 2, len(expired) - 1):
+                    logger.warning(
+                        "lease.expired.requeued",
+                        task_id=task_id,
+                        attempt=entry.attempt,
+                        retries=entry.retry_count,
+                    )
+
+    def _push_ready(self, entry: _TaskEntry) -> None:
+        self._sequence += 1
+        heapq.heappush(self._ready, (entry.priority, self._sequence, entry))
+
+    def _push_delayed(self, entry: _TaskEntry) -> None:
+        self._sequence += 1
+        heapq.heappush(self._delayed, (entry.visible_at, self._sequence, entry))
+
+    def _promote_ready(self, now: float) -> None:
+        while self._delayed and self._delayed[0][0] <= now:
+            _, _, entry = heapq.heappop(self._delayed)
+            self._push_ready(entry)
+
+    def put(self, entries: Sequence[_TaskEntry]) -> None:
+        with self._lock:
+            now = time.time()
+            for idx, entry in enumerate(entries):
+                if entry.expires_at is not None and entry.expires_at <= now:
+                    continue
+                if entry.visible_at <= now:
+                    self._push_ready(entry)
+                else:
+                    self._push_delayed(entry)
+                if idx in (0, len(entries) // 2, len(entries) - 1):
+                    logger.info(
+                        "task.put",
+                        task_id=entry.task.task_id,
+                        priority=entry.priority,
+                        visible_at=entry.visible_at,
+                    )
+            self._log_queue_state("queue.updated")
+
+    def lease(self, max_n: int, lease_ttl: float, filters: Optional[Mapping[str, Union[str, int, float]]] = None) -> List[_TaskEntry]:
+        leased: List[_TaskEntry] = []
+        with self._lock:
+            now = time.time()
+            self._requeue_expired_locked(now)
+            self._promote_ready(now)
+            if not self._ready:
+                return leased
+            count = min(max_n, len(self._ready))
+            skipped: List[Tuple[int, int, _TaskEntry]] = []
+            for _ in range(count):
+                priority, seq, entry = heapq.heappop(self._ready)
+                if entry.expires_at is not None and entry.expires_at <= now:
+                    continue
+                if not self._match_filters(entry, filters):
+                    skipped.append((priority, seq, entry))
+                    continue
+                entry.lease_id = uuid.uuid4().hex
+                entry.lease_deadline = now + lease_ttl
+                entry.attempt += 1
+                entry.metadata.setdefault("last_lease_ttl", lease_ttl)
+                self._leased[entry.task.task_id] = entry
+                leased.append(entry)
+            for item in skipped:
+                heapq.heappush(self._ready, item)
+            for idx, entry in enumerate(leased):
+                if idx in (0, len(leased) // 2, len(leased) - 1):
+                    logger.debug(
+                        "task.leased",
+                        task_id=entry.task.task_id,
+                        lease_deadline=entry.lease_deadline,
+                        attempt=entry.attempt,
+                    )
+        return leased
+
+    def ack(self, task_id: str) -> bool:
+        with self._lock:
+            entry = self._leased.pop(task_id, None)
+            if entry is None:
+                return False
+            logger.info("task.ack", task_id=task_id, attempt=entry.attempt)
+            return True
+
+    def nack(self, task_id: str, *, requeue: bool, delay: Optional[float]) -> bool:
+        with self._lock:
+            entry = self._leased.pop(task_id, None)
+            if entry is None:
+                return False
+            entry.last_exception = entry.last_exception
+            entry.last_reason = "nack"
+            now = time.time()
+            if requeue:
+                entry.visible_at = now + (delay or 0.0)
+                entry.lease_deadline = None
+                entry.lease_id = None
+                entry.retry_count += 1
+                if entry.visible_at <= now:
+                    self._push_ready(entry)
+                else:
+                    self._push_delayed(entry)
+                logger.warning(
+                    "task.nack.requeued",
+                    task_id=task_id,
+                    delay=delay,
+                    retries=entry.retry_count,
+                )
+            else:
+                self._dead[task_id] = entry
+                logger.error("task.nack.dead", task_id=task_id)
+            return True
+
+    def heartbeat(self, task_id: str) -> bool:
+        with self._lock:
+            entry = self._leased.get(task_id)
+            if entry is None or entry.lease_deadline is None:
+                return False
+            ttl = float(entry.metadata.get("last_lease_ttl", 0.0))
+            if ttl <= 0:
+                return False
+            entry.lease_deadline = time.time() + ttl
+            logger.debug("task.heartbeat", task_id=task_id, ttl=ttl)
+            return True
+
+    def mark_dead(self, task_id: str, reason: str) -> bool:
+        with self._lock:
+            entry = self._leased.pop(task_id, None)
+            if entry is None:
+                entry = self._pop_from_heaps(task_id)
+            if entry is None:
+                return False
+            entry.last_reason = reason
+            self._dead[task_id] = entry
+            logger.error("task.dead", task_id=task_id, reason=reason)
+            return True
+
+    def stats(self) -> Mapping[str, Union[int, float]]:
+        with self._lock:
+            now = time.time()
+            self._promote_ready(now)
+            visible = len(self._ready)
+            leased = len(self._leased)
+            dead = len(self._dead)
+            return {
+                "visible": visible,
+                "leased": leased,
+                "dead": dead,
+                "total": visible + leased + dead,
+            }
+
+    def drain(self, predicate: Callable[[TaskRecord], bool]) -> List[TaskRecord]:
+        drained: List[TaskRecord] = []
+        with self._lock:
+            now = time.time()
+            all_entries = self._collect_entries()
+            self._ready.clear()
+            self._delayed.clear()
+            for entry in all_entries:
+                if predicate(entry.task):
+                    drained.append(entry.task)
+                else:
+                    if entry.visible_at <= now:
+                        self._push_ready(entry)
+                    else:
+                        self._push_delayed(entry)
+            logger.info("task.drain", drained=len(drained))
+        return drained
+
+    def _collect_entries(self) -> List[_TaskEntry]:
+        ready_entries = [entry for _, _, entry in self._ready]
+        delayed_entries = [entry for _, _, entry in self._delayed]
+        return ready_entries + delayed_entries
+
+    def snapshot_entries(self) -> List[_TaskEntry]:
+        return self._collect_entries() + list(self._leased.values())
+
+    def _pop_from_heaps(self, task_id: str) -> Optional[_TaskEntry]:
+        found: Optional[_TaskEntry] = None
+        rebuilt_ready: List[Tuple[int, int, _TaskEntry]] = []
+        while self._ready:
+            priority, seq, entry = heapq.heappop(self._ready)
+            if entry.task.task_id == task_id and found is None:
+                found = entry
+                continue
+            rebuilt_ready.append((priority, seq, entry))
+        for item in rebuilt_ready:
+            heapq.heappush(self._ready, item)
+        rebuilt_delayed: List[Tuple[float, int, _TaskEntry]] = []
+        while self._delayed:
+            visible_at, seq, entry = heapq.heappop(self._delayed)
+            if entry.task.task_id == task_id and found is None:
+                found = entry
+                continue
+            rebuilt_delayed.append((visible_at, seq, entry))
+        for item in rebuilt_delayed:
+            heapq.heappush(self._delayed, item)
+        return found
+
+
+class FileBackend(TaskPoolBackend):
+    def __init__(self, path: Union[str, os.PathLike[str]]) -> None:
+        self._path = Path(path)
+        self._lock = threading.RLock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._queue: InMemoryBackend = InMemoryBackend()
+        if self._path.exists():
+            self._load()
+
+    def _load(self) -> None:
+        with self._path.open("r", encoding="utf-8") as fh:
+            rows = [json.loads(line) for line in fh if line.strip()]
+        entries: List[_TaskEntry] = []
+        for row in rows:
+            task_data = dict(row["task"])
+            task_data["payload_ref"] = tuple(task_data.get("payload_ref", []))
+            task_data["group_keys"] = tuple(task_data.get("group_keys", []))
+            record = TaskRecord(**task_data)
+            entry = _TaskEntry(
+                task=record,
+                priority=row["priority"],
+                visible_at=row["visible_at"],
+                expires_at=row.get("expires_at"),
+                lease_deadline=None,
+                lease_id=None,
+                attempt=row.get("attempt", 0),
+                idempotency_key=row.get("idempotency_key"),
+                metadata=row.get("metadata", {}),
+                last_exception=row.get("last_exception"),
+                last_reason=row.get("last_reason"),
+                retry_count=row.get("retry_count", 0),
+            )
+            entries.append(entry)
+        self._queue.put(entries)
+
+    def _persist(self) -> None:
+        entries: List[Dict[str, Union[str, int, float, None, Dict[str, Union[str, int, float, None]]]]] = []
+        for entry in self._queue.snapshot_entries():
+            entries.append(
+                {
+                    "task": entry.task.to_dict(),
+                    "priority": entry.priority,
+                    "visible_at": entry.visible_at,
+                    "expires_at": entry.expires_at,
+                    "attempt": entry.attempt,
+                    "idempotency_key": entry.idempotency_key,
+                    "metadata": dict(entry.metadata),
+                    "last_exception": entry.last_exception,
+                    "last_reason": entry.last_reason,
+                    "retry_count": entry.retry_count,
+                }
+            )
+        tmp_path = self._path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            for row in entries:
+                fh.write(json.dumps(row) + "\n")
+        os.replace(tmp_path, self._path)
+
+    def put(self, entries: Sequence[_TaskEntry]) -> None:
+        with self._lock:
+            self._queue.put(entries)
+            self._persist()
+
+    def lease(self, max_n: int, lease_ttl: float, filters: Optional[Mapping[str, Union[str, int, float]]] = None) -> List[_TaskEntry]:
+        with self._lock:
+            leased = self._queue.lease(max_n, lease_ttl, filters)
+            self._persist()
+            return leased
+
+    def ack(self, task_id: str) -> bool:
+        with self._lock:
+            ok = self._queue.ack(task_id)
+            self._persist()
+            return ok
+
+    def nack(self, task_id: str, *, requeue: bool, delay: Optional[float]) -> bool:
+        with self._lock:
+            ok = self._queue.nack(task_id, requeue=requeue, delay=delay)
+            self._persist()
+            return ok
+
+    def heartbeat(self, task_id: str) -> bool:
+        with self._lock:
+            ok = self._queue.heartbeat(task_id)
+            self._persist()
+            return ok
+
+    def mark_dead(self, task_id: str, reason: str) -> bool:
+        with self._lock:
+            ok = self._queue.mark_dead(task_id, reason)
+            self._persist()
+            return ok
+
+    def stats(self) -> Mapping[str, Union[int, float]]:
+        return self._queue.stats()
+
+    def drain(self, predicate: Callable[[TaskRecord], bool]) -> List[TaskRecord]:
+        with self._lock:
+            drained = self._queue.drain(predicate)
+            self._persist()
+            return drained
+
+
+def _backend_from_config() -> TaskPoolBackend:
+    settings = get_pool_value("backend", dict, default={})
+    backend_type = str(settings.get("type", "memory")).lower()
+    if backend_type == "memory":
+        return InMemoryBackend()
+    if backend_type == "file":
+        path = settings.get("path")
+        if not path:
+            raise RuntimeError("File backend requires 'path' in configuration")
+        return FileBackend(str(path))
+    raise ValueError(f"Unsupported task pool backend: {backend_type}")
+
+
+class TaskPool:
+    def __init__(
+        self,
+        backend: Optional[TaskPoolBackend] = None,
+        *,
+        default_ttl: Optional[float] = None,
+    ) -> None:
+        self._backend = backend or _backend_from_config()
+        ttl_raw = get_pool_value("default_ttl", Any, default=None)
+        config_ttl = float(ttl_raw) if ttl_raw is not None else None
+        self._default_ttl = default_ttl if default_ttl is not None else config_ttl
+        self._idempotency_index: Dict[str, str] = {}
+        self._lock = threading.RLock()
+        logger.info(
+            "task_pool.initialised",
+            backend=self._backend.__class__.__name__,
+            default_ttl=self._default_ttl,
+        )
+
+    def put(
+        self,
+        tasks: Union[TaskRecord, Sequence[TaskRecord]],
+        *,
+        ttl: Optional[float] = None,
+        priority: Optional[int] = None,
+        idempotency_key: Optional[str] = None,
+        metadata: Optional[Mapping[str, Union[str, int, float, None]]] = None,
+    ) -> None:
+        if isinstance(tasks, TaskRecord):
+            iterable = [tasks]
+        else:
+            iterable = list(tasks)
+        ttl = ttl if ttl is not None else self._default_ttl
+        now = time.time()
+        entries: List[_TaskEntry] = []
+        with self._lock:
+            for idx, task in enumerate(iterable):
+                key = idempotency_key or str(task.extras.get("idempotency_key", "")) or task.task_id
+                if key in self._idempotency_index:
+                    logger.debug("task.put.skip_duplicate", task_id=task.task_id, key=key)
+                    continue
+                entry = _TaskEntry(
+                    task=task,
+                    priority=priority if priority is not None else task.priority or 0,
+                    visible_at=now,
+                    expires_at=(now + ttl) if ttl is not None else None,
+                    lease_deadline=None,
+                    lease_id=None,
+                    attempt=0,
+                    idempotency_key=key,
+                    metadata=dict(metadata or {}),
+                )
+                self._idempotency_index[key] = task.task_id
+                entries.append(entry)
+                if idx in (0, len(iterable) // 2, len(iterable) - 1):
+                    logger.debug("task.put.entry", task_id=task.task_id, key=key)
+        if entries:
+            self._backend.put(entries)
+
+    def lease(
+        self,
+        max_n: int,
+        lease_ttl: float,
+        *,
+        filters: Optional[Mapping[str, Union[str, int, float]]] = None,
+    ) -> List[LeasedTask]:
+        raw = self._backend.lease(max_n, lease_ttl, filters)
+        leased = [
+            LeasedTask(
+                task=entry.task,
+                lease_id=entry.lease_id or "",
+                lease_deadline=entry.lease_deadline or 0.0,
+                attempt=entry.attempt,
+                metadata=entry.metadata,
+            )
+            for entry in raw
+        ]
+        return leased
+
+    def ack(self, task_id: str) -> bool:
+        if self._backend.ack(task_id):
+            with self._lock:
+                for key, value in list(self._idempotency_index.items()):
+                    if value == task_id:
+                        self._idempotency_index.pop(key, None)
+            return True
+        return False
+
+    def nack(self, task_id: str, *, requeue: bool = True, delay: Optional[float] = None) -> bool:
+        return self._backend.nack(task_id, requeue=requeue, delay=delay)
+
+    def heartbeat(self, task_id: str) -> bool:
+        return self._backend.heartbeat(task_id)
+
+    def mark_dead(self, task_id: str, reason: str) -> bool:
+        return self._backend.mark_dead(task_id, reason)
+
+    def stats(self) -> Mapping[str, Union[int, float]]:
+        return self._backend.stats()
+
+    def drain(self, predicate: Callable[[TaskRecord], bool]) -> List[TaskRecord]:
+        drained = self._backend.drain(predicate)
+        with self._lock:
+            for task in drained:
+                for key, value in list(self._idempotency_index.items()):
+                    if value == task.task_id:
+                        self._idempotency_index.pop(key, None)
+        return drained
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import unittest
+    from task_partitioner import TaskPartitioner
+
+    class TaskPoolTests(unittest.TestCase):
+        def setUp(self) -> None:
+            plan = TaskPartitioner.plan(
+                {"job_id": "job-1"},
+                [
+                    {"payload_ref": "item-1", "weight": 1.0, "group_key": "A"},
+                    {"payload_ref": "item-2", "weight": 1.0, "group_key": "A"},
+                    {"payload_ref": "item-3", "weight": 1.0, "group_key": "B"},
+                ],
+                "fixed",
+                {"max_items_per_task": 2},
+            )
+            self.tasks = plan.tasks
+            self.task_count = len(self.tasks)
+            self.pool = TaskPool()
+
+        def test_put_and_lease(self) -> None:
+            self.pool.put(self.tasks)
+            leased = self.pool.lease(2, 5.0)
+            self.assertEqual(len(leased), 2)
+            stats = self.pool.stats()
+            self.assertEqual(stats["leased"], 2)
+
+        def test_ack_removes_task(self) -> None:
+            self.pool.put(self.tasks)
+            leased = self.pool.lease(1, 5.0)
+            task_id = leased[0].task.task_id
+            self.assertTrue(self.pool.ack(task_id))
+            stats = self.pool.stats()
+            self.assertEqual(stats["leased"], 0)
+
+        def test_nack_requeues(self) -> None:
+            self.pool.put(self.tasks)
+            leased = self.pool.lease(1, 1.0)
+            task_id = leased[0].task.task_id
+            self.assertTrue(self.pool.nack(task_id, requeue=True, delay=0.0))
+            leased_again = self.pool.lease(2, 1.0)
+            self.assertIn(task_id, {entry.task.task_id for entry in leased_again})
+
+        def test_lease_expiry(self) -> None:
+            self.pool.put(self.tasks)
+            leased = self.pool.lease(1, 0.1)
+            task_id = leased[0].task.task_id
+            time.sleep(0.2)
+            leased_again = self.pool.lease(2, 0.1)
+            task_ids = {lease.task.task_id for lease in leased_again}
+            self.assertIn(task_id, task_ids)
+
+        def test_mark_dead_moves_task(self) -> None:
+            self.pool.put(self.tasks)
+            leased = self.pool.lease(1, 1.0)
+            task_id = leased[0].task.task_id
+            self.assertTrue(self.pool.mark_dead(task_id, "test"))
+            stats = self.pool.stats()
+            self.assertEqual(stats["dead"], 1)
+
+        def test_drain_removes_tasks(self) -> None:
+            self.pool.put(self.tasks)
+            drained = self.pool.drain(lambda task: task.payload_ref[0] == "item-1")
+            self.assertTrue(drained)
+            stats = self.pool.stats()
+            self.assertEqual(stats["visible"], max(0, self.task_count - len(drained)))
+
+    unittest.main()

--- a/task_system_config.py
+++ b/task_system_config.py
@@ -1,0 +1,61 @@
+"""Shared helpers for task system configuration."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from config import Config
+
+_TASK_CONFIG_ENV = "CAD_TASK_CONFIG"
+_DEFAULT_CONFIG_NAME = "main.yaml"
+
+
+def _resolve_config_path() -> Path:
+    env_path = os.environ.get(_TASK_CONFIG_ENV)
+    if env_path:
+        path = Path(env_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Configured task system file not found: {path}")
+        return path
+    default_path = Path(__file__).with_name(_DEFAULT_CONFIG_NAME)
+    if not default_path.exists():
+        raise FileNotFoundError(
+            "Task system configuration file not found. Set CAD_TASK_CONFIG or "
+            f"place {_DEFAULT_CONFIG_NAME} alongside the modules."
+        )
+    return default_path
+
+
+def ensure_task_config() -> Config:
+    """Return the Config singleton initialised with task system settings."""
+    try:
+        return Config.get_singleton()
+    except RuntimeError:
+        path = _resolve_config_path()
+        return Config.load_singleton(path)
+
+
+def _task_config_key(key: str) -> str:
+    return f"task_system.{key}" if key else "task_system"
+
+
+def get_task_value(key: str, typ: type, default: Any = None, *, required: bool = False) -> Any:
+    cfg = ensure_task_config()
+    value = cfg.get(_task_config_key(key), typ, default)
+    if required and value is None:
+        raise RuntimeError(f"Missing required configuration key: {_task_config_key(key)}")
+    return value
+
+
+def get_pool_value(key: str, typ: type, default: Any = None, *, required: bool = False) -> Any:
+    return get_task_value(f"pool.{key}", typ, default, required=required)
+
+
+def get_executor_value(key: str, typ: type, default: Any = None, *, required: bool = False) -> Any:
+    return get_task_value(f"executor.{key}", typ, default, required=required)
+
+
+def reset_task_config() -> None:
+    """Clear the Config singleton (primarily for tests)."""
+    Config.set_singleton(None)

--- a/yaml.py
+++ b/yaml.py
@@ -1,0 +1,171 @@
+"""Minimal YAML loader for configurations when PyYAML is unavailable."""
+
+import json
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+class SafeLoader:
+    """Compatibility shim exposing the subset of the PyYAML SafeLoader API."""
+
+    _constructors: Dict[str, Callable[["SafeLoader", Any], Any]] = {}
+
+    def __init__(self, stream: Any) -> None:
+        self._text = _read_stream(stream)
+        self._constructors = self.__class__._constructors.copy()
+
+    @classmethod
+    def add_constructor(cls, tag: str, constructor: Callable[["SafeLoader", Any], Any]) -> None:
+        cls._constructors[tag] = constructor
+
+    def read(self) -> str:
+        return self._text
+
+    def construct_scalar(self, node: Any) -> Any:  # pragma: no cover - shim only
+        return node
+
+
+_NUMERIC_RE = re.compile(r"^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$")
+
+
+def _read_stream(stream: Any) -> str:
+    if isinstance(stream, SafeLoader):
+        return stream.read()
+    if hasattr(stream, "read"):
+        return stream.read()
+    return str(stream)
+
+
+def _parse_scalar(token: str) -> Any:
+    token = token.strip()
+    if not token:
+        return None
+    if token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    lowered = token.lower()
+    if lowered in {"null", "~"}:
+        return None
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if _NUMERIC_RE.match(token):
+        if any(c in token for c in ".eE"):
+            try:
+                return float(token)
+            except Exception:
+                return token
+        try:
+            return int(token)
+        except Exception:
+            return token
+    if token.startswith("[") and token.endswith("]"):
+        try:
+            return json.loads(token)
+        except Exception:
+            return token
+    if token.startswith("{") and token.endswith("}"):
+        try:
+            return json.loads(token)
+        except Exception:
+            return token
+    return token
+
+
+def _tokenize(text: str) -> List[str]:
+    return [line.rstrip("\n") for line in text.splitlines()]
+
+
+def _next_non_empty(lines: List[str], start: int) -> Tuple[Optional[int], Optional[int]]:
+    i = start
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped and not stripped.startswith("#"):
+            return i, len(lines[i]) - len(lines[i].lstrip(" "))
+        i += 1
+    return None, None
+
+
+def _parse_block(lines: List[str], index: int, indent: int) -> Tuple[Any, int]:
+    seq: Optional[List[Any]] = None
+    mapping: Dict[str, Any] = {}
+    i = index
+    while i < len(lines):
+        raw = lines[i]
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        cur_indent = len(raw) - len(raw.lstrip(" "))
+        if cur_indent < indent:
+            break
+        if cur_indent > indent:
+            raise ValueError(f"Unexpected indentation at line {i + 1}: {raw!r}")
+        if stripped.startswith("- "):
+            if seq is None:
+                if mapping:
+                    raise ValueError("Cannot mix list and mapping entries at the same level")
+                seq = []
+            value_part = stripped[2:].strip()
+            child_indent = cur_indent + 2
+            if not value_part:
+                child, i = _parse_block(lines, i + 1, child_indent)
+                seq.append(child)
+                continue
+            if ":" in value_part and not value_part.startswith("{"):
+                key, rest = value_part.split(":", 1)
+                item: Dict[str, Any] = {key.strip(): _parse_scalar(rest.strip())}
+                j = i + 1
+                while True:
+                    next_index, next_indent = _next_non_empty(lines, j)
+                    if next_index is None or next_indent is None or next_indent <= cur_indent:
+                        break
+                    child_map, j = _parse_block(lines, next_index, child_indent)
+                    if not isinstance(child_map, dict):
+                        raise ValueError("List item continuation must be a mapping")
+                    item.update(child_map)
+                seq.append(item)
+                i = j
+                continue
+            seq.append(_parse_scalar(value_part))
+            i += 1
+            continue
+        if seq is not None:
+            raise ValueError("Cannot mix list and mapping entries at the same level")
+        if ":" not in stripped:
+            raise ValueError(f"Expected key-value pair at line {i + 1}: {raw!r}")
+        key, rest = stripped.split(":", 1)
+        key = key.strip()
+        rest = rest.strip()
+        if rest:
+            mapping[key] = _parse_scalar(rest)
+            i += 1
+            continue
+        child, i = _parse_block(lines, i + 1, indent + 2)
+        mapping[key] = child
+    return (seq if seq is not None else mapping), i
+
+
+def load(stream: Any, Loader: Optional[Callable[[Any], SafeLoader]] = None) -> Any:
+    if Loader is None:
+        text = _read_stream(stream)
+    else:
+        loader = Loader(stream)
+        text = loader.read() if hasattr(loader, "read") else _read_stream(loader)
+    if isinstance(text, bytes):
+        text = text.decode("utf-8")
+    text = text.strip()
+    if not text:
+        return None
+    if text.lstrip().startswith("{") or text.lstrip().startswith("["):
+        return json.loads(text)
+    lines = _tokenize(text)
+    data, _ = _parse_block(lines, 0, 0)
+    return data
+
+
+def safe_dump(data: Any, sort_keys: bool = True, allow_unicode: bool = True) -> str:
+    return json.dumps(data, sort_keys=sort_keys, ensure_ascii=not allow_unicode)
+
+
+__all__ = ["SafeLoader", "load", "safe_dump"]


### PR DESCRIPTION
## Summary
- merge task system settings into main.yaml and retire the extra task_system.yaml file
- update configuration helpers to resolve the unified file name and keep the config demo pointing at it
- expand the YAML fallback loader so the combined configuration continues to load without PyYAML

## Testing
- python task_pool.py
- python parallel_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68e4cfe9ed408327a339237bc03c3cf0