### PR TITLE
Fix S2 pipeline dataset root paths and inline defaults

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -2,10 +2,10 @@ version: 1
 config:
   version: 1
 app:
-  name: ${APP_NAME:my-service}
-  env: ${APP_ENV:dev}
+  name: my-service
+  env: dev
   tz_store: UTC
-  tz_render: ${LOG_RENDER_TZ:Europe/London}
+  tz_render: Europe/London
 runtime:
   tz: UTC
 io:
@@ -20,23 +20,23 @@ db:
 secrets:
   db_password: env:DB_PASS
 logger:
-  level: ${LOG_LEVEL:INFO}
-  namespace: ${LOG_NAMESPACE:cad.tabpfn}
+  level: INFO
+  namespace: cad.tabpfn
   timezone:
-    render: ${LOG_RENDER_TZ:Europe/London}
+    render: Europe/London
   sinks:
     - type: console
       stream: stdout
     - type: rotating_file
-      path: ${LOG_FILE_PATH:logs/app.log}
-      max_bytes: ${LOG_FILE_MAX_BYTES:10485760}
-      backups: ${LOG_FILE_BACKUPS:5}
+      path: logs/app.log
+      max_bytes: 10485760
+      backups: 5
   sampling:
-    default_rate: ${LOG_SAMPLING_DEFAULT:1.0}
-    seed: ${LOG_SAMPLING_SEED:42}
+    default_rate: 1.0
+    seed: 42
     rules:
       - level: DEBUG
-        rate: ${LOG_SAMPLING_DEBUG_RATE:0.1}
+        rate: 0.1
         burst: 5
         interval: 60
   redact:
@@ -77,17 +77,17 @@ pipelines:
     sources:
       - dataset: MFInstSeg
         tier: gold
-        root: /workspace/Gjj Local/data/CAD/CAD_data/MFInstSeg}
+        root: "/workspace/Gjj Local/data/CAD/CAD_data/MFInstSeg"
         pattern: "**/*"
         allowed_extensions: [".step", ".stp", ".stpz", ".brep", ".brp"]
       - dataset: MFCAD
         tier: silver
-        root: /workspace/Gjj Local/data/CAD/CAD_data/MFCAD}
+        root: "/workspace/Gjj Local/data/CAD/CAD_data/MFCAD"
         pattern: "**/*"
         allowed_extensions: [".step", ".stp", ".stpz", ".brep", ".brp"]
       - dataset: MFCAD2
         tier: silver
-        root: /workspace/Gjj Local/data/CAD/CAD_data/MFCAD2}
+        root: "/workspace/Gjj Local/data/CAD/CAD_data/MFCAD2"
         pattern: "**/*"
         allowed_extensions: [".step", ".stp", ".stpz", ".brep", ".brp"]
     sampling:
@@ -116,7 +116,7 @@ pipelines:
         max_items_per_task: 128
         shuffle_seed: 42
     outputs:
-      root: /workspace/Gjj Local/data/CAD/step_out/s2_out}
+      root: "/workspace/Gjj Local/data/CAD/step_out/s2_out"
       signatures_file: signatures.parquet
       part_index_file: part_index.csv
       part_index_for_split_file: part_index.for_split.csv


### PR DESCRIPTION
## Summary
- remove stray braces from S2 dataset and output root paths
- quote root paths to safely handle spaces in directory names
- inline YAML defaults instead of relying on environment-variable placeholders

## Testing
- not run (dataset paths unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e504da67588327b8bda618111cb58a